### PR TITLE
query ADS with "identifier"

### DIFF
--- a/ads2gephi/ads2gephi.py
+++ b/ads2gephi/ads2gephi.py
@@ -36,7 +36,7 @@ class Node:
             self._article = db_article
         elif bibcode:
             _query = ads.SearchQuery(
-                bibcode=bibcode,
+                identifier=bibcode,
                 token=ADS_API_KEY,
                 fl=['bibcode', 'year', 'author', 'title', 'reference', 'citation']
             )


### PR DESCRIPTION
When you use "bibcode=" in ads.SearchQuery, it runs a query with `bibcode:` in the ADS query, which only works with canonical bibcodes. Instead, replacing this with "identifier=" will do an "identifier:" query in ADS, which will also query all deleted and alternate bibcodes. 